### PR TITLE
Updated CMakeLists to build a bit more easily on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,3 +96,6 @@ include_directories(${NETWORKIT_TTMATH_EXT})
 target_link_libraries(GNI_predictors PUBLIC networkit)
 target_link_libraries(GNI_predictors PUBLIC ${ARMADILLO_LIBRARIES})
 target_link_libraries(GNI_predictors PUBLIC ${Boost_LIBRARIES})
+
+# Install config
+install(TARGETS GNI_predictors DESTINATION "bin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,104 +1,98 @@
-cmake_minimum_required(VERSION 3.5)
-
-
+cmake_minimum_required(VERSION 3.9)
 
 project(GNI_predictors LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-add_compile_options(-O9 -g -finline-functions -m64)
-# Enable sanitizers - To take account run this: "cmake -DCMAKE_ASAN=ON .."
-if(CMAKE_ASAN)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined")
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
 endif()
 
+set(CMAKE_OPTIMIZATION_LEVEL_PRIVATE "-O0")
+if(CMAKE_BUILD_TYPE MATCHES "Release" OR CMAKE_BUILD_TYPE MATCHES
+                                         "RelWithDebInfo")
+  set(CMAKE_OPTIMIZATION_LEVEL_PRIVATE "-O3")
+endif()
+
+if(CMAKE_OPTIMIZATION_LEVEL)
+  set(CMAKE_OPTIMIZATION_LEVEL_PRIVATE "-O${CMAKE_OPTIMIZATION_LEVEL}")
+endif()
+
+set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${CMAKE_OPTIMIZATION_LEVEL_PRIVATE}")
+
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO
+    "-DDEBUG ${CMAKE_OPTIMIZATION_LEVEL_PRIVATE} -g")
+
+set(CMAKE_CXX_FLAGS_DEBUG
+    "-DDEBUG ${CMAKE_OPTIMIZATION_LEVEL_PRIVATE} -g -Wall -Wextra -Wpedantic")
+
+# Enable sanitizers - To take account run this: "cmake -DCMAKE_ASAN=ON .."
+if(CMAKE_ASAN)
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined"
+  )
+endif()
 
 include(ExternalProject)
 
-find_package(Armadillo REQUIRED)
-find_package(Boost COMPONENTS date_time filesystem system program_options)
-if(UNIX)
-    set(LOCAL_BOOST_DIR "${CMAKE_BINARY_DIR}/lib/src/boost")
-    set(BOOST_SHA256_HASH 9995e192e68528793755692917f9eb6422f3052a53c5e13ba278a228af6c7acf)
-    set(BOOST_DOWNLOAD_LINK "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.gz")
-else()
-    set(LOCAL_BOOST_DIR "${CMAKE_BINARY_DIR}/lib/src/boost")
-    set(BOOST_SHA256_HASH 0909a79524f857ef54570ceef8f397cc0629202532cc997785479c7c08bbc2a4)
-    set(BOOST_DOWNLOAD_LINK "https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.zip")
-endif()
+# ##############################################################################
+# External Libs
+# ##############################################################################
 
+# Armadillo
+find_package(Armadillo REQUIRED)
 include_directories(${ARMADILLO_INCLUDE_DIRS})
 
-set(Boost_USE_STATIC_LIBS        ON) # only find static libs
-set(Boost_USE_RELEASE_LIBS       ON)  # only find release libs
-set(Boost_USE_MULTITHREADED      ON)
-set(Boost_USE_STATIC_RUNTIME    OFF)
+# Boost
+set(Boost_USE_STATIC_LIBS OFF) # only find static libs
+set(Boost_USE_RELEASE_LIBS ON) # only find release libs
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
+find_package(Boost REQUIRED COMPONENTS date_time filesystem system
+                                       program_options)
 
-
-if(${Boost_FOUND})
-    include_directories(${Boost_INCLUDE_DIRS})
-
-else()
-   # set(Boost_LIBRARIES "${CMAKE_BINARY_DIR}/lib/src/networkit-build/lib/libboost_date_time.so;${CMAKE_BINARY_DIR}/lib/src/networkit-build/lib/libboost_filesystem.so;${CMAKE_BINARY_DIR}/lib/src/networkit-build/lib/libboost_system.so;${CMAKE_BINARY_DIR}/lib/src/networkit-build/lib/program_options.so")
-    set(Boost_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/lib/src/networkit/include")
-    ExternalProject_Add(
-      Boost
-      URL         ${LOCAL_DOWNLOAD_LINK}
-      URL_HASH    SHA256=${BOOST_SHA256_HASH}
-      UPDATE_DISCONNECTED ON
-      INSTALL_COMMAND     ""
-      TMP_DIR             /tmp
-      DOWNLOAD_DIR        ${CMAKE_BINARY_DIR}/lib/src
-      SOURCE_DIR          ${CMAKE_BINARY_DIR}/lib/src/boost
-      BINARY_DIR          ${CMAKE_BINARY_DIR}/lib/src/boost-build
-    )
-    find_package(Boost COMPONENTS date_time filesystem system program_options)
-    message(STATUS "${Boost_LIBRARIES}")
-endif()
-
+# NetworKit we build ourselves
 set(NETWORKIT_SRC_DIR "${CMAKE_BINARY_DIR}/lib/src/networkit")
 set(NETWORKIT_BIN_DIR "${CMAKE_BINARY_DIR}/lib/src/networkit-build")
 set(NETWORKIT_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/lib/src/networkit/include")
 set(NETWORKIT_TLX_EXT "${CMAKE_BINARY_DIR}/lib/src/networkit/extlibs/tlx")
 set(NETWORKIT_TTMATH_EXT "${CMAKE_BINARY_DIR}/lib/src/networkit/extlibs/ttmath")
 
-
 ExternalProject_Add(
   NetworKit
-  GIT_REPOSITORY      https://github.com/networkit/networkit.git
-  GIT_TAG             origin/release-6.1
+  CMAKE_ARGS "-DNETWORKIT_STATIC=ON"
+  GIT_REPOSITORY https://github.com/networkit/networkit.git
+  GIT_TAG origin/release-6.1
   UPDATE_DISCONNECTED ON
-  INSTALL_COMMAND     ""
-  TMP_DIR             /tmp
-  DOWNLOAD_DIR        ${CMAKE_BINARY_DIR}/lib/src
-  SOURCE_DIR          ${NETWORKIT_SRC_DIR}
-  BINARY_DIR          ${NETWORKIT_BIN_DIR}
-)
+  INSTALL_COMMAND ""
+  TMP_DIR /tmp
+  DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/lib/src
+  SOURCE_DIR ${NETWORKIT_SRC_DIR}
+  BINARY_DIR ${NETWORKIT_BIN_DIR})
 
+# OpenMP
+find_package(OpenMP COMPONENTS CXX REQUIRED)
+if(OPENMP_CXX_FOUND)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+  set(CMAKE_EXE_LINKER_FLAGS
+      "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+endif()
+
+# Setup target
+add_executable(GNI_predictors src/gnip.cpp src/matrixPreparation.cpp
+                              src/randomWalk.cpp)
+
+# Need to manually register NetworKit as a dep
+add_dependencies(GNI_predictors NetworKit)
+
+# Setup some more dirs the compiler needs to know about
+target_include_directories(GNI_predictors PRIVATE src)
+target_link_directories(GNI_predictors PUBLIC ${NETWORKIT_BIN_DIR})
 include_directories(${NETWORKIT_INCLUDE_DIRS})
 include_directories(${NETWORKIT_TLX_EXT})
 include_directories(${NETWORKIT_TTMATH_EXT})
 
-add_executable(GNI_predictors src/gnip.cpp
-                              src/matrixPreparation.cpp
-                              src/randomWalk.cpp)
-target_include_directories(GNI_predictors PRIVATE src)
-
-target_link_libraries(GNI_predictors PUBLIC "${NETWORKIT_BIN_DIR}/libnetworkit.so")
+# Link stuff
+target_link_libraries(GNI_predictors PUBLIC networkit)
 target_link_libraries(GNI_predictors PUBLIC ${ARMADILLO_LIBRARIES})
-if(NOT TARGET OpenMP::OpenMP_CXX)
-    find_package(Threads REQUIRED)
-    add_library(OpenMP::OpenMP_CXX IMPORTED INTERFACE)
-    set_property(TARGET OpenMP::OpenMP_CXX
-                 PROPERTY INTERFACE_COMPILE_OPTIONS ${OpenMP_CXX_FLAGS})
-    # Only works if the same flag is passed to the linker; use CMake 3.9+ otherwise (Intel, AppleClang)
-    set_property(TARGET OpenMP::OpenMP_CXX
-                 PROPERTY INTERFACE_LINK_LIBRARIES ${OpenMP_CXX_FLAGS} Threads::Threads)
-endif()
-
-target_link_libraries(GNI_predictors PUBLIC OpenMP::OpenMP_CXX)
-
-if(${Boost_FOUND})
-    target_link_libraries(GNI_predictors PUBLIC ${Boost_LIBRARIES})
-
-endif()
-
+target_link_libraries(GNI_predictors PUBLIC ${Boost_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -1,9 +1,21 @@
 # gni_predictors
 
 This implementation is an alpha version library that will include different functional gene predictors. Only the tool NewGOA is provided. To use the gni_predictor tool we need to download from the GitHub repository. Then, into the repository, It is recommended to create a 'build' folder before compile and into it execute the following commands (make sure that you have "Armadillo" installed):
+
+### Dependencies
+
+* OpenMP (Needs separate Clang install on OS X)
+* Boost (with devel headers)
+* Aramdillo (with devel headers)
+
+### Installation
+
 ```
+mkdir build && cd build
 cmake ..
 make
+make install
+
 ```
 Now you should have a executable called `GNI_predictors`.
 


### PR DESCRIPTION
* Added NetworKit as a direct dependency
* Made Boost, OpenMP and Armadillo required dependencies since they're easy to install in just about every package manager, so no need for us to build them from source
* Set NetworKit as a static build and static link so we can install easily without having to manage a dynamic library
* Added install targets and a few more configuration options
